### PR TITLE
Sphere as a primitive in the space model

### DIFF
--- a/nndt/math_core.py
+++ b/nndt/math_core.py
@@ -108,3 +108,20 @@ def uniform_in_cube(rng_key: KeyArray, count=100, lower=(-2, -2, -2), upper=(2, 
     y = jax.random.uniform(rng_key, shape=(count, 1), minval=lower[1], maxval=upper[1])
     z = jax.random.uniform(rng_key, shape=(count, 1), minval=lower[2], maxval=upper[2])
     return jnp.hstack([x, y, z])
+
+
+def sdf_primitive_sphere(center=(0., 0., 0.), radius=1.):
+    def prim(x: float, y: float, z: float):
+        sdf = (x - center[0])**2 + (y - center[1])**2 + (z - center[2])**2 - radius**2
+        return sdf
+    vec_prim = jax.vmap(prim)
+
+    prim_x = jax.grad(prim, argnums=0)
+    prim_y = jax.grad(prim, argnums=1)
+    prim_z = jax.grad(prim, argnums=2)
+
+    vec_prim_x = jax.vmap(prim_x)
+    vec_prim_y = jax.vmap(prim_y)
+    vec_prim_z = jax.vmap(prim_z)
+
+    return vec_prim, vec_prim_x, vec_prim_y, vec_prim_z

--- a/nndt/space/abstracts.py
+++ b/nndt/space/abstracts.py
@@ -44,12 +44,19 @@ class AbstractRegion:
 
 
 class AbstractSource:
+    def __init__(self):
+        self.name = ""
+    def __repr__(self):
+        return Fore.LIGHTBLUE_EX + f'{str(self.__class__.__name__)}("{self.name}")' + Fore.RESET
+
+
+class FileSource(AbstractSource):
 
     def __init__(self, filepath):
+        super(FileSource, self).__init__()
         if not os.path.exists(filepath):
             raise FileNotFoundError()
         self.filepath = filepath
-        self.name = ""
 
     def __repr__(self):
         return Fore.LIGHTBLUE_EX + f'{str(self.__class__.__name__)}("{self.name}", filename="{os.path.basename(self.filepath)}")' + Fore.RESET

--- a/nndt/space/loaders.py
+++ b/nndt/space/loaders.py
@@ -6,6 +6,8 @@ from sklearn.model_selection import train_test_split
 from nndt.space.regions import *
 from nndt.space.repr_mesh import *
 from nndt.space.repr_sdt import *
+from nndt.space.repr_prim import SphereSDF_Xyz2SDT, SphereSDF
+from nndt.space.sources import SphereSDFSource
 
 
 def preload_all_possible(space: Space,
@@ -34,6 +36,10 @@ def preload_all_possible(space: Space,
 
             _ = Xyz2SDT(repr)
             _ = Xyz2LocalSDT(repr)
+
+        if isinstance(node, SphereSDFSource):
+            repr = SphereSDF(node, name="repr")
+            _ = SphereSDF_Xyz2SDT(repr)
 
     gc.collect()
 

--- a/nndt/space/repr_mesh.py
+++ b/nndt/space/repr_mesh.py
@@ -16,7 +16,7 @@ from nndt.space.vtk_wrappers import *
 
 class MeshRepr(AbstractRegion, ExtendedNodeMixin, UnloadMixin):
 
-    def __init__(self, parent: AbstractSource, surface_mesh2: SurfaceMesh,
+    def __init__(self, parent: FileSource, surface_mesh2: SurfaceMesh,
                  physical_center: (float, float, float),
                  physical_bbox: ((float, float, float), (float, float, float)),
                  normed_center: (float, float, float),

--- a/nndt/space/repr_prim.py
+++ b/nndt/space/repr_prim.py
@@ -36,4 +36,4 @@ class SphereSDF_Xyz2SDT(AbstractMethod, ExtendedNodeMixin):
 
     def __call__(self, ns_xyz: jnp.ndarray) -> jnp.ndarray:
         ns_sdt = self.parent.vec_prim(ns_xyz[:, 0], ns_xyz[:, 1], ns_xyz[:, 2])
-        return ns_sdt
+        return ns_sdt[...,jnp.newaxis]

--- a/nndt/space/repr_prim.py
+++ b/nndt/space/repr_prim.py
@@ -1,0 +1,39 @@
+import jax.numpy as jnp
+
+from nndt.math_core import sdf_primitive_sphere
+from nndt.space.abstracts import *
+from nndt.space.sources import SphereSDFSource
+
+
+class SphereSDF(AbstractRegion, ExtendedNodeMixin):
+
+    def __init__(self, parent: SphereSDFSource,
+                 name=""):
+        center = parent.center
+        radius = parent.radius
+        super(SphereSDF, self).__init__(_ndim=3,
+                                        _bbox=((center[0] - radius, center[1] - radius, center[2] - radius),
+                                               (center[0] + radius, center[1] + radius, center[2] + radius)),
+                                        name=name)
+        self.name = name
+        self.parent = parent
+
+        self._print_color = Fore.GREEN
+
+        fun = sdf_primitive_sphere(center=center, radius=radius)
+        self.vec_prim, self.vec_prim_x, self.vec_prim_y, self.vec_prim_z = fun
+
+
+class SphereSDF_Xyz2SDT(AbstractMethod, ExtendedNodeMixin):
+
+    def __init__(self, parent: SphereSDF):
+        super(SphereSDF_Xyz2SDT, self).__init__()
+        self.name = "xyz2sdt"
+        self.parent = parent
+
+    def __repr__(self):
+        return f'xyz2sdt(ns_xyz[...,3]) -> ns_sdt[...,1]'
+
+    def __call__(self, ns_xyz: jnp.ndarray) -> jnp.ndarray:
+        ns_sdt = self.parent.vec_prim(ns_xyz[:, 0], ns_xyz[:, 1], ns_xyz[:, 2])
+        return ns_sdt

--- a/nndt/space/repr_sdt.py
+++ b/nndt/space/repr_sdt.py
@@ -10,7 +10,7 @@ from nndt.space.vtk_wrappers import *
 class SDTRepr(AbstractRegion, ExtendedNodeMixin, UnloadMixin):
     MAGIC_CORRECTION = 0.503  # This is absolutely magic coefficient that reduce error between bboxes to 0.49075 mm
 
-    def __init__(self, parent: AbstractSource, sdt_explicit_array2: SDTExplicitArray,
+    def __init__(self, parent: FileSource, sdt_explicit_array2: SDTExplicitArray,
                  physical_center: (float, float, float),
                  physical_bbox: ((float, float, float), (float, float, float)),
                  normed_center: (float, float, float),

--- a/nndt/space/sources.py
+++ b/nndt/space/sources.py
@@ -1,7 +1,7 @@
-from nndt.space.abstracts import AbstractSource, ExtendedNodeMixin
+from nndt.space.abstracts import FileSource, ExtendedNodeMixin, AbstractSource
 
 
-class MeshSource(AbstractSource, ExtendedNodeMixin):
+class MeshSource(FileSource, ExtendedNodeMixin):
 
     def __init__(self, name, filepath, parent=None):
         super(MeshSource, self).__init__(filepath)
@@ -9,9 +9,20 @@ class MeshSource(AbstractSource, ExtendedNodeMixin):
         self.parent = parent
 
 
-class SDTSource(AbstractSource, ExtendedNodeMixin):
+class SDTSource(FileSource, ExtendedNodeMixin):
 
     def __init__(self, name, filepath, parent=None):
         super(SDTSource, self).__init__(filepath)
         self.name = name
         self.parent = parent
+
+
+class SphereSDFSource(AbstractSource, ExtendedNodeMixin):
+
+    def __init__(self, name, center=(0., 0., 0.), radius=1., parent=None):
+        super(SphereSDFSource, self).__init__()
+        self.name = name
+        self.parent = parent
+
+        self.center = center
+        self.radius = radius

--- a/tests/test_math_core.py
+++ b/tests/test_math_core.py
@@ -38,6 +38,34 @@ class MathCoreTestCase(unittest.TestCase):
         self.assertEqual([1, 5, 9, 3], list(array))
         self.assertEqual([1, 5, 9, 3], list(index_set))
 
+    def test_sdf_primitive_sphere(self):
+        vec_prim, vec_prim_x, vec_prim_y, vec_prim_z = sdf_primitive_sphere()
+        xyz = jnp.array([[0., 0., 0.], [0., 0., 1.], [0., 0., 2.]])
+
+        self.assertTrue(bool(jnp.allclose(jnp.array([-1., 0., 3.]),
+                                          vec_prim(xyz[:, 0], xyz[:, 1], xyz[:, 2]))))
+        self.assertTrue(bool(jnp.allclose(jnp.array([0., 0., 0.]),
+                                          vec_prim_x(xyz[:, 0], xyz[:, 1], xyz[:, 2]))))
+        self.assertTrue(bool(jnp.allclose(jnp.array([0., 0., 0.]),
+                                          vec_prim_y(xyz[:, 0], xyz[:, 1], xyz[:, 2]))))
+        self.assertTrue(bool(jnp.allclose(jnp.array([0., 2., 4.]),
+                                          vec_prim_z(xyz[:, 0], xyz[:, 1], xyz[:, 2]))))
+
+    def test_sdf_primitive_sphere2(self):
+        vec_prim, vec_prim_x, vec_prim_y, vec_prim_z = sdf_primitive_sphere(
+                        center=(1., 1., 1.),
+                        radius=float(jnp.sqrt(1**2 + 1**2 + 1**2)))
+        xyz = jnp.array([[0., 0., 0.]])
+
+        self.assertTrue(bool(jnp.allclose(jnp.array([0., 0., 0.]),
+                                          vec_prim(xyz[:, 0], xyz[:, 1], xyz[:, 2]))))
+        self.assertTrue(bool(jnp.allclose(jnp.array([-2., -2., -2.]),
+                                          vec_prim_x(xyz[:, 0], xyz[:, 1], xyz[:, 2]))))
+        self.assertTrue(bool(jnp.allclose(jnp.array([-2., -2., -2.]),
+                                          vec_prim_y(xyz[:, 0], xyz[:, 1], xyz[:, 2]))))
+        self.assertTrue(bool(jnp.allclose(jnp.array([-2., -2., -2.]),
+                                          vec_prim_z(xyz[:, 0], xyz[:, 1], xyz[:, 2]))))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_space_model.py
+++ b/tests/test_space_model.py
@@ -225,8 +225,11 @@ class MyTestCase(unittest.TestCase):
         mesh_source = SphereSDFSource("region",
                                       parent=object)
         preload_all_possible(mesh_source)
-        #TODO HERE CHECK XYZ REQUEST
         print(space.explore())
+
+        xyz = jnp.array([[0., 0., 0.], [1., 0., 0.], [2., 0., 0.]])
+        ret = space['default/test/region/repr/xyz2sdt'](xyz)
+        self.assertTrue(jnp.allclose(jnp.array([[-1.], [0.], [3.]]), ret))
 
 
 if __name__ == '__main__':

--- a/tests/test_space_model.py
+++ b/tests/test_space_model.py
@@ -198,6 +198,16 @@ class MyTestCase(unittest.TestCase):
         self.assertTrue(float(xyz.min()) < -5)
         self.assertTrue(5< float(xyz.max()))
 
+    def test_create_SphereSDFSource(self):
+        space = Space("main")
+        group = Group("default", parent=space)
+        object = Object("test", parent=group)
+        mesh_source = SphereSDFSource("region",
+                                      center=(0., 0., 0.),
+                                      radius=2.,
+                                      parent=object)
+        print(space.explore())
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_space_model.py
+++ b/tests/test_space_model.py
@@ -208,6 +208,26 @@ class MyTestCase(unittest.TestCase):
                                       parent=object)
         print(space.explore())
 
+    def test_create_SphereSDF_from_SphereSDFSource(self):
+        space = Space("main")
+        group = Group("default", parent=space)
+        object = Object("test", parent=group)
+        mesh_source = SphereSDFSource("region",
+                                      center=(0., 0., 0.),
+                                      radius=2.,
+                                      parent=object)
+        print(space.explore())
+
+    def test_create_SphereSDF_from_SphereSDFSource(self):
+        space = Space("main")
+        group = Group("default", parent=space)
+        object = Object("test", parent=group)
+        mesh_source = SphereSDFSource("region",
+                                      parent=object)
+        preload_all_possible(mesh_source)
+        #TODO HERE CHECK XYZ REQUEST
+        print(space.explore())
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
There are all classes and methods for present the sphere as a geometry primitive in the normed space.

- `sdf_primitive_sphere` in `math_core` provide the SDF function and it derivatives
- `space_model` is extended with new source and representation for the sphere
-  our lovely `preload_all_possible` is magically extended for the magical support of the magic sphere representation.